### PR TITLE
Player movement and jump in mobile devices

### DIFF
--- a/src/js/sprites/player.js
+++ b/src/js/sprites/player.js
@@ -57,7 +57,7 @@ export class Player extends Phaser.Sprite {
     isJumping() {
         return this.game.input.keyboard.isDown(Phaser.Keyboard.W) || this.pad &&
         (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_UP) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_Y) > 0.1) ||
-        this.game.input.activePointer.positionDown && this.game.input.activePointer.position.y - this.game.input.activePointer.positionDown.y < -PLAYER_JUMP_SWIPE_THRESHOLD;
+        this.game.input.activePointer.isDown && this.game.input.activePointer.position.y - this.game.input.activePointer.positionDown.y < -PLAYER_JUMP_SWIPE_THRESHOLD;
     }
 
     loseHealth(health) {

--- a/src/js/sprites/player.js
+++ b/src/js/sprites/player.js
@@ -2,6 +2,7 @@ const PLAYER_MAX_HEALTH = 3;
 const PLAYER_FALL_SPEED_LIMIT = 1000;
 const PLAYER_VELOCITY = 300;
 const PLAYER_JUMP_VELOCITY = 300;
+const PLAYER_JUMP_SWIPE_THRESHOLD = 50;
 export const PLAYER_SPIKE_VELOCITY = 50;
 
 export class Player extends Phaser.Sprite {
@@ -55,7 +56,8 @@ export class Player extends Phaser.Sprite {
 
     isJumping() {
         return this.game.input.keyboard.isDown(Phaser.Keyboard.W) || this.pad &&
-        (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_UP) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_Y) > 0.1);
+        (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_UP) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_Y) > 0.1) ||
+        this.game.input.activePointer.positionDown && this.game.input.activePointer.position.y - this.game.input.activePointer.positionDown.y < -PLAYER_JUMP_SWIPE_THRESHOLD;
     }
 
     loseHealth(health) {

--- a/src/js/sprites/player.js
+++ b/src/js/sprites/player.js
@@ -35,11 +35,13 @@ export class Player extends Phaser.Sprite {
     }
 
     isMovingLeft() {
-        return this.game.input.keyboard.isDown(Phaser.Keyboard.A) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_LEFT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) < -0.1);
+        return this.game.input.keyboard.isDown(Phaser.Keyboard.A) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_LEFT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) < -0.1) ||
+        this.game.input.activePointer.isDown && this.game.input.activePointer.position.x < this.position.x;
     }
 
     isMovingRight() {
-        return this.game.input.keyboard.isDown(Phaser.Keyboard.D) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_RIGHT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) > 0.1);
+        return this.game.input.keyboard.isDown(Phaser.Keyboard.D) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_RIGHT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) > 0.1) ||
+        this.game.input.activePointer.isDown && this.game.input.activePointer.position.x > this.position.x;
     }
 
     loseHealth(health) {

--- a/src/js/sprites/player.js
+++ b/src/js/sprites/player.js
@@ -1,6 +1,7 @@
 const PLAYER_MAX_HEALTH = 3;
 const PLAYER_FALL_SPEED_LIMIT = 1000;
 const PLAYER_VELOCITY = 300;
+const PLAYER_JUMP_VELOCITY = 300;
 export const PLAYER_SPIKE_VELOCITY = 50;
 
 export class Player extends Phaser.Sprite {
@@ -32,6 +33,10 @@ export class Player extends Phaser.Sprite {
         if(this.body.velocity.y > PLAYER_FALL_SPEED_LIMIT) {
             this.tooFast = true;
         }
+
+        if (this.canJump() && this.isJumping()) {
+            this.body.velocity.y = -PLAYER_JUMP_VELOCITY;
+        }
     }
 
     isMovingLeft() {
@@ -40,8 +45,17 @@ export class Player extends Phaser.Sprite {
     }
 
     isMovingRight() {
-        return this.game.input.keyboard.isDown(Phaser.Keyboard.D) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_RIGHT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) > 0.1) ||
+        return this.game.input.keyboard.isDown(Phaser.Keyboard.D) || this.pad && (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_LEFT) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_X) < -0.1) ||
         this.game.input.activePointer.isDown && this.game.input.activePointer.position.x > this.position.x;
+    }
+
+    canJump() {
+        return this.body.blocked.down;
+    }
+
+    isJumping() {
+        return this.game.input.keyboard.isDown(Phaser.Keyboard.W) || this.pad &&
+        (this.pad.isDown(Phaser.Gamepad.XBOX360_DPAD_UP) || this.pad.axis(Phaser.Gamepad.XBOX360_STICK_LEFT_Y) > 0.1);
     }
 
     loseHealth(health) {


### PR DESCRIPTION
Add player movement with touch actions. It's a simple implementation and need some fixed for edge cases like touching the center of the sprite.
Add jump action with W key and swipe.
